### PR TITLE
HTTPS is now mandatory for repo.maven.apache.org, update repo URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
     }
 
     maven {
-        url = 'http://repo.maven.apache.org/maven2'
+        url = 'https://repo.maven.apache.org/maven2'
     }
 }
 


### PR DESCRIPTION
per Announcement: https://blog.sonatype.com/central-repository-moving-to-https