### PR TITLE
add bin/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ infinitest.filters
 konik.iml
 build/
 .gradle/
+bin/


### PR DESCRIPTION
gradle puts binary .class files into a bin/ folder that should be excluded from Git.